### PR TITLE
fixing id not found on system

### DIFF
--- a/building_module/__manifest__.py
+++ b/building_module/__manifest__.py
@@ -23,11 +23,11 @@ Long description of module's purpose
     # always loaded
     'data': [
         'security/ir.model.access.csv',
-        'views/estate_menus.xml',
         'views/estate_property_views.xml',
         'views/estate_property_type_views.xml',
         'views/estate_property_tag_views.xml',
         'views/estate_property_offer_views.xml',
+        'views/estate_menus.xml',
     ],
     # only loaded in demonstration mode
     'demo': [


### PR DESCRIPTION
Reorder the XML definitions so that the action (estate_property_action) is defined before the menu